### PR TITLE
Add Python tests for modern blocks and entities

### DIFF
--- a/src/main/resources/test/test_honey_block.py
+++ b/src/main/resources/test/test_honey_block.py
@@ -1,0 +1,18 @@
+import mcpi.minecraft as minecraft
+import mcpi.block as block
+import time
+
+mc = minecraft.Minecraft.create()
+
+mc.postToChat("Test: place HONEY_BLOCK")
+time.sleep(1)
+
+x, y, z = mc.player.getPos()
+
+try:
+    mc.setBlock(x + 1, y, z, block.HONEY_BLOCK)
+    mc.postToChat("Block successfully placed!")
+except AttributeError:
+    mc.postToChat("The MCPI API does not know 'HONEY_BLOCK'.")
+except Exception as e:
+    mc.postToChat(f"Server error: {e}")

--- a/src/main/resources/test/test_kelp_block.py
+++ b/src/main/resources/test/test_kelp_block.py
@@ -1,0 +1,18 @@
+import mcpi.minecraft as minecraft
+import mcpi.block as block
+import time
+
+mc = minecraft.Minecraft.create()
+
+mc.postToChat("Test: place KELP")
+time.sleep(1)
+
+x, y, z = mc.player.getPos()
+
+try:
+    mc.setBlock(x + 1, y, z, block.KELP)
+    mc.postToChat("Block successfully placed!")
+except AttributeError:
+    mc.postToChat("The MCPI API does not know 'KELP'.")
+except Exception as e:
+    mc.postToChat(f"Server error: {e}")

--- a/src/main/resources/test/test_netherite_block.py
+++ b/src/main/resources/test/test_netherite_block.py
@@ -1,0 +1,18 @@
+import mcpi.minecraft as minecraft
+import mcpi.block as block
+import time
+
+mc = minecraft.Minecraft.create()
+
+mc.postToChat("Test: place NETHERITE_BLOCK")
+time.sleep(1)
+
+x, y, z = mc.player.getPos()
+
+try:
+    mc.setBlock(x + 1, y, z, block.NETHERITE_BLOCK)
+    mc.postToChat("Block successfully placed!")
+except AttributeError:
+    mc.postToChat("The MCPI API does not know 'NETHERITE_BLOCK'.")
+except Exception as e:
+    mc.postToChat(f"Server error: {e}")

--- a/src/main/resources/test/test_spawn_axolotl.py
+++ b/src/main/resources/test/test_spawn_axolotl.py
@@ -1,0 +1,19 @@
+import mcpi.minecraft as minecraft
+import mcpi.entity as entity
+import time
+
+mc = minecraft.Minecraft.create()
+
+mc.postToChat("Test: spawn AXOLOTL")
+time.sleep(1)
+
+x, y, z = mc.player.getPos()
+
+try:
+    axolotl = getattr(entity, "AXOLOTL")
+    mc.spawnEntity(x + 2, y, z, axolotl)
+    mc.postToChat("Entity successfully spawned!")
+except AttributeError:
+    mc.postToChat("The MCPI API does not know 'AXOLOTL'.")
+except Exception as e:
+    mc.postToChat(f"Server error: {e}")


### PR DESCRIPTION
## Summary
- add Python test scripts for Honey, Netherite and Kelp blocks
- add Python test script attempting to spawn an Axolotl entity

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68931b2aa22c833095611646035be4e9